### PR TITLE
Make crawler not crawl and as a consequence ... speed up things a lot!

### DIFF
--- a/nroam.el
+++ b/nroam.el
@@ -44,6 +44,7 @@
 (defvar-local nroam-start-marker nil)
 (defvar-local nroam-end-marker nil)
 
+(defvar nroam-work-buffer " nroam-work")
 (defmacro with-nroam-markers (&rest body)
   "Evaluate BODY.
 Make the region inserted by BODY read-only, and marked with
@@ -68,12 +69,19 @@ Make the region inserted by BODY read-only, and marked with
   :keymap nroam-mode-map
   (if nroam-mode
       (progn
+        (nroam--init-work-buffer)
         (add-hook 'before-save-hook #'nroam--prune-backlinks nil t)
         (add-hook 'after-save-hook #'nroam--update-backlinks-maybe nil t)
         (nroam-update-backlinks))
     (remove-hook 'before-save-hook #'nroam--prune-backlinks t)
     (remove-hook 'after-save-hook #'nroam--update-backlinks-maybe t)
     (nroam--prune-backlinks)))
+
+(defun nroam--init-work-buffer ()
+  (get-buffer-create nroam-work-buffer t)
+  (with-current-buffer nroam-work-buffer
+    (delay-mode-hooks
+      (org-mode))))
 
 (defun nroam-ctrl-c-ctrl-c ()
   "Update the backlinks for the current buffer, or fallback to `org-ctrl-c-ctrl-c'."
@@ -198,14 +206,14 @@ Make the region inserted by BODY read-only, and marked with
 
 (defun nroam--crawl-source (file point)
   "Return the source element in FILE at POINT."
-  (with-current-buffer (find-file-noselect file)
-    (save-excursion
-      (goto-char point)
-      (let ((elt (org-element-at-point)))
-        (let ((begin (org-element-property :begin elt))
-              (end (org-element-property :end elt))
-              (type (org-element-type elt)))
-          `(,type . ,(buffer-substring begin end)))))))
+  (with-current-buffer nroam-work-buffer
+    (insert-file-contents file nil nil nil 'replace)
+    (goto-char point)
+    (let ((elt (org-element-at-point)))
+      (let ((begin (org-element-property :begin elt))
+            (end (org-element-property :end elt))
+            (type (org-element-type elt)))
+        `(,type . ,(buffer-substring begin end))))))
 
 (defun nroam--fix-links (content origin)
   "Correct all relative links in CONTENT from ORIGIN.

--- a/nroam.el
+++ b/nroam.el
@@ -45,6 +45,7 @@
 (defvar-local nroam-end-marker nil)
 
 (defvar nroam-work-buffer " nroam-work")
+
 (defmacro with-nroam-markers (&rest body)
   "Evaluate BODY.
 Make the region inserted by BODY read-only, and marked with
@@ -78,6 +79,7 @@ Make the region inserted by BODY read-only, and marked with
     (nroam--prune-backlinks)))
 
 (defun nroam--init-work-buffer ()
+  "Initiate nroam hidden buffer."
   (get-buffer-create nroam-work-buffer t)
   (with-current-buffer nroam-work-buffer
     (delay-mode-hooks

--- a/readme.org
+++ b/readme.org
@@ -26,8 +26,3 @@ It can also be manually updated by typing =C-c C-c= anywhere in the linked refer
 * Warning
 
 This package is in its infancy. Be careful when using it as it modifies your =org-mode= buffers—it should not modify your files though. Backup your data often.
-
-* Performance
-
-At the moment no caching is done when crawling source files for backlinks so there could be performance issues with very large number of org files as a lot of buffers could have to be open to crawl backlink content.
-


### PR DESCRIPTION
Do with this what you wish. :)

Some might consider it "ugly" since we're introducing a special hidden work-buffer for the crawler to use. Maybe a temp-buffer would be just as good. I didn't profile it to see how big of an improvement the declared hidden buffer is compared to just using temp-buffers. But compared to the original code, this it's fast! Orders of magnitude. At least on windows machines. Should be the same on Linux. Also: No hooks, no bloat in the buffer-list for the user.