### PR TITLE
Set visibility of backlinks section

### DIFF
--- a/nroam.el
+++ b/nroam.el
@@ -185,12 +185,18 @@ Make the region inserted by BODY read-only, and marked with
 
 (defun nroam--insert ()
   "Insert nroam sections in the current buffer."
-  (with-buffer-modified-unmodified
-   (save-excursion
-     (goto-char (point-max))
-     (with-nroam-markers
-       (seq-do #'funcall nroam-sections)))
-   (nroam--hide-drawers)))
+  (let ((p (point-max)))
+    (with-buffer-modified-unmodified
+     (save-excursion
+       (goto-char p)
+       (with-nroam-markers
+         (seq-do #'funcall nroam-sections))
+       (when (nroam--sections-inserted-p)
+         (goto-char (+ p 1)) ; maybe to implicit. But loc. of new
+                             ; backlinks section
+         (save-restriction
+           (org-narrow-to-subtree)
+           (org-set-startup-visibility)))))))
 
 (defun nroam--get-backlinks ()
   "Return a list of backlinks for the current buffer."

--- a/nroam.el
+++ b/nroam.el
@@ -192,10 +192,8 @@ Make the region inserted by BODY read-only, and marked with
        (with-nroam-markers
          (seq-do #'funcall nroam-sections))
        (when (nroam--sections-inserted-p)
-         (goto-char (+ p 1)) ; maybe to implicit. But loc. of new
-                             ; backlinks section
          (save-restriction
-           (org-narrow-to-subtree)
+           (narrow-to-region p (point-max))
            (org-set-startup-visibility)))))))
 
 (defun nroam--get-backlinks ()


### PR DESCRIPTION
Make nroam respect visibility startup options.

I'm not proud of the `(+ p 1)` part, but my elementary tests say it works just fine!

* nroam.el (nroam--insert): Set visibility according to
startup-options.