### PR TITLE
Remove nroam sections from export

### DIFF
--- a/nroam-backlinks.el
+++ b/nroam-backlinks.el
@@ -56,7 +56,7 @@
 
 (defun nroam-backlinks--insert-heading (count)
   "Insert the heading for the backlinks section with a COUNT."
-  (insert (format "* %s %s\n"
+  (insert (format "* %s %s                          :noexport:\n"
                   (if (= count 0) "No" count)
                   (nroam--pluralize count "linked reference"))))
 

--- a/nroam-unlinked.el
+++ b/nroam-unlinked.el
@@ -44,7 +44,7 @@
 
 (defun nroam-unlinked--insert-heading ()
   "Insert the heading for unlinked references."
-  (insert "* Unlinked references\n"))
+  (insert "* Unlinked references                      :noexport:\n"))
 
 (defun nroam-unlinked--insert-references ()
   "Insert unlinked references for the current buffer."


### PR DESCRIPTION
Without this commit, the 2 sections that nroam adds to org-roam buffers are exported with the rest of the buffer's content. This commit makes sure that org won't export these 2 sections.