### PR TITLE
Organize backlinks under single heading

### DIFF
--- a/nroam-backlinks.el
+++ b/nroam-backlinks.el
@@ -56,19 +56,19 @@
 
 (defun nroam-backlinks--insert-heading (count)
   "Insert the heading for the backlinks section with a COUNT."
-  (insert (format "* %s %s                          :noexport:\n"
-                  (if (= count 0) "No" count)
-                  (nroam--pluralize count "linked reference"))))
+  (let ((title (format "%s %s"
+                       (if (= count 0) "No" count)
+                       (nroam--pluralize count "linked reference"))))
+    (nroam--insert-heading 2 title)))
 
 (defun nroam-backlinks--insert-group (group)
   "Insert all backlinks in GROUP."
   (let ((file (car group))
-        (backlinks (cdr group)))
-    (insert (format "** %s\n"
-                    (org-roam-format-link
-                     file
-                     (org-roam-db--get-title file)
-                     "file")))
+        (backlinks (cdr group))
+        (title (org-roam-format-link file
+                                     (org-roam-db--get-title file)
+                                     "file")))
+    (nroam--insert-heading 3 title)
     (nroam--do-separated-by-newlines #'nroam-backlinks--insert-backlink backlinks)))
 
 (defun nroam-backlinks--insert-backlink (backlink)

--- a/nroam-unlinked.el
+++ b/nroam-unlinked.el
@@ -44,7 +44,7 @@
 
 (defun nroam-unlinked--insert-heading ()
   "Insert the heading for unlinked references."
-  (insert "* Unlinked references                      :noexport:\n"))
+  (nroam--insert-heading 2 "Unlinked references"))
 
 (defun nroam-unlinked--insert-references ()
   "Insert unlinked references for the current buffer."

--- a/nroam-utils.el
+++ b/nroam-utils.el
@@ -34,6 +34,16 @@
   (let ((inhibit-read-only t))
     (unless (eq ?\n (char-before (1- (point)))) (insert "\n"))))
 
+(defun nroam--insert-heading (level title &optional tags)
+  "Insert a section heading"
+  (let ((pos (point))
+        (stars (make-string level ?*)))
+    (insert stars " " title "\n")
+    (when tags
+      (save-excursion
+      (goto-char pos)
+      (org-set-tags tags)))))
+
 (defun nroam--do-separated-by-newlines (function sequence)
   "Apply FUNCTION to each element of SEQUENCE.
 Insert a single newline between each call to FUNCTION."

--- a/nroam-utils.el
+++ b/nroam-utils.el
@@ -35,7 +35,8 @@
     (unless (eq ?\n (char-before (1- (point)))) (insert "\n"))))
 
 (defun nroam--insert-heading (level title &optional tags)
-  "Insert a section heading"
+  "Insert TITLE as a section heading with LEVEL stars.
+Add the string or list of strings as TAGS to the heading."
   (let ((pos (point))
         (stars (make-string level ?*)))
     (insert stars " " title "\n")

--- a/nroam.el
+++ b/nroam.el
@@ -186,6 +186,7 @@ Make the region inserted by BODY read-only, and marked with
      (unless (bobp)
        (nroam--ensure-empty-line))
      (with-nroam-markers
+       (nroam--insert-heading 1 "Backlinks" "noexport")
        (nroam--do-separated-by-newlines #'funcall nroam-sections))
      (nroam--set-sections-visibility))))
 


### PR DESCRIPTION
This creates a single `Backlinks` heading with the `:noexport:` tag, and everything else under it.
Heading creation factored out as `nroam--insert-heading`.